### PR TITLE
[Chore] Added links to the socials buttons in the footer

### DIFF
--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -47,10 +47,26 @@ export const FOOTER_LINKS = {
     { label: "Location", href: "/location" },
   ],
   socials: [
-    { label: "Instagram", href: "https://instagram.com", icon: "Instagram" },
-    { label: "Twitter", href: "https://twitter.com", icon: "Twitter" },
-    { label: "YouTube", href: "https://youtube.com", icon: "Youtube" },
-    { label: "Facebook", href: "https://facebook.com", icon: "Facebook" },
+    {
+      label: "Instagram",
+      href: "https://www.instagram.com/rise.basketball/",
+      icon: "Instagram",
+    },
+    {
+      label: "Twitter",
+      href: "https://x.com/_Risebasketball",
+      icon: "Twitter",
+    },
+    {
+      label: "YouTube",
+      href: "https://www.youtube.com/@rise.basketball",
+      icon: "Youtube",
+    },
+    {
+      label: "Facebook",
+      href: "https://www.facebook.com/RisebasketballCalgary/",
+      icon: "Facebook",
+    },
   ],
 };
 


### PR DESCRIPTION
# ✨ Changes Made

<!-- List what you changed, fixed, or added -->
- Added links in the footer for RISE basketball, Instagram, Twitter / X, Youtube, and Facebook

---

# 🧠 Reason for Changes

<!-- Explain why this change was necessary -->
- Added links so when the user clicks on the button it will take them to RISE accounts instead of the apps main page.
---

# 🧪 Testing Performed

<!-- Confirm what testing was done -->

- [ ✓ ] Frontend tested locally (`npm run dev`)
- [ ✓ ] No console errors (Frontend)

---

# 🔗 Related Trello Task

<!-- Link to the related Trello card -->
https://trello.com/c/QzxpmdWZ/107-footer-fix-socials-links

---