### PR TITLE
[Chore] Added countdown timer on supplements page

### DIFF
--- a/app/supplements/page.tsx
+++ b/app/supplements/page.tsx
@@ -14,6 +14,7 @@ import { ThreeDCard } from "@/components/ui/3d-card";
 import { AnimatedText } from "@/components/ui/animated-text";
 import PartnerLogos from "@/components/partner-logos";
 import { SUPPLEMENT_PRODUCTS } from "@/lib/constants";
+import CountdownTimer from "@/components/countdown-timer";
 
 export default function SupplementsPage() {
   return (
@@ -193,6 +194,15 @@ export default function SupplementsPage() {
       <SectionContainer id="products">
         <SectionHeading title="Premium Supplements" centered />
         <ProductGrid products={SUPPLEMENT_PRODUCTS} />
+      </SectionContainer>
+
+      {/* Coming Soon */}
+      <SectionContainer className="bg-black" id="coming-soon">
+        <SectionHeading title="Coming Soon - FALL 2026" centered />
+
+        <div className="p-8 rounded-lg max-w-3xl mx-auto mb-8">
+          <CountdownTimer targetDate="2026-09-01T00:00:00" />
+        </div>
       </SectionContainer>
 
       {/* ProRise Innovation */}


### PR DESCRIPTION
# ✨ Changes Made

<!-- List what you changed, fixed, or added -->
- Added a countdown timer to the Supplements Page, set it for FALL 2026

---

# 🧠 Reason for Changes

<!-- Explain why this change was necessary -->
- Added the timer since the Supplements is coming soon so users have an idea of when it is available. 
---

# 🧪 Testing Performed

<!-- Confirm what testing was done -->

- [ ✓ ] Frontend tested locally (`npm run dev`)
- [ ✓ ] No console errors (Frontend)

---

# 📸 Screenshots or Screen Recording 

<!-- Attach screenshots or recordings if visual/UI changes were made -->
![image](https://github.com/user-attachments/assets/118d6c1b-656c-437c-a487-628824010dd9)

---

# 🔗 Related Trello Task

<!-- Link to the related Trello card -->
https://trello.com/c/miz8dbaw/93-supplements-page-under-premium-supplements-add-countdown-timer
---

