### PR TITLE
[Feature] Added rotating top players component

### DIFF
--- a/app/basketball/page.tsx
+++ b/app/basketball/page.tsx
@@ -17,8 +17,14 @@ import { StatsCounter } from "@/components/ui/stats-counter";
 import PartnerLogos from "@/components/partner-logos";
 import TabNavigation from "@/components/tab-navigation";
 import { useState } from "react";
-import { MEMBERSHIP_PLANS, UPCOMING_GAMES, TOP_PLAYERS } from "@/lib/constants";
+import {
+  MEMBERSHIP_PLANS,
+  UPCOMING_GAMES,
+  TOP_PLAYERS,
+  TOP3,
+} from "@/lib/constants";
 import { Play } from "lucide-react";
+import { RotatingPlayerStats, Player } from "@/components/rotating-top-players";
 
 export default function BasketballPage() {
   const [activeTab, setActiveTab] = useState("schedules");
@@ -453,21 +459,17 @@ export default function BasketballPage() {
               <h2 className="text-white text-2xl font-bold mb-4">
                 PLAYER STATISTICS
               </h2>
-              <ThreeDCard>
-                <PlayerStatsCard
-                  name="CADE CUNNINGHAM"
-                  position="POINT GUARD"
-                  ppg={23.2}
-                />
-              </ThreeDCard>
+              <div>
+                <RotatingPlayerStats players={TOP3} />
+              </div>
             </div>
             <div>
               <h2 className="text-white text-2xl font-bold mb-4">
                 TOP PLAYERS
               </h2>
-              <ThreeDCard>
+              <div>
                 <TopPlayersTable players={TOP_PLAYERS} />
-              </ThreeDCard>
+              </div>
             </div>
           </div>
         </SectionContainer>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import type React from "react";
 import type { Metadata } from "next/types";
 import { Inter } from "next/font/google";
 import "./globals.css";
+import "@/styles/globals.css";
 import Header from "@/components/header";
 import Footer from "@/components/footer";
 import ScrollToTop from "@/components/scroll-to-top";

--- a/components/rotating-top-players.tsx
+++ b/components/rotating-top-players.tsx
@@ -1,0 +1,114 @@
+import { useState, useEffect, useRef } from "react";
+import { cn } from "@/lib/utils";
+import { PlayerStatsCard } from "./ui/player-stats-card";
+
+export interface Player {
+  id: string;
+  name: string;
+  position: string;
+  ppg: number;
+  avatar?: string;
+}
+
+interface RotatingPlayerStatsProps {
+  players: Player[];
+  interval?: number;
+  className?: string;
+}
+
+export function RotatingPlayerStats({
+  players,
+  interval = 4000,
+  className,
+}: RotatingPlayerStatsProps) {
+  const [current, setCurrent] = useState(0);
+  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const clearTimer = () => {
+    if (timerRef.current) clearInterval(timerRef.current);
+  };
+  const startTimer = () => {
+    clearTimer();
+    timerRef.current = setInterval(() => {
+      setCurrent((i) => (i + 1) % players.length);
+    }, interval);
+  };
+
+  useEffect(() => {
+    startTimer();
+    return clearTimer;
+  }, [players.length, interval]);
+
+  const handleNext = () => {
+    clearTimer();
+    setCurrent((i) => (i + 1) % players.length);
+    startTimer();
+  };
+
+  const handleBack = () => {
+    clearTimer();
+    setCurrent((i) => (i - 1 + players.length) % players.length);
+    startTimer();
+  };
+
+  return (
+    <div
+      className={cn(
+        "bg-black/90 backdrop-blur-sm rounded-lg border border-gray-800",
+        className
+      )}
+    >
+      {/* Top */}
+      <div className="px-2 pt-2">
+        <div className="relative h-[275px]">
+          {players.map((p, i) => (
+            <div
+              key={p.id}
+              className={`
+            absolute inset-0
+            transition-opacity duration-700 ease-in-out
+            ${i === current ? "opacity-100" : "opacity-0"}
+          `}
+            >
+              <PlayerStatsCard
+                name={p.name}
+                position={p.position}
+                ppg={p.ppg}
+                avatar={p.avatar}
+                className="bg-transparent border-none shadow-none"
+              />
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Bottom: controls + progress bar */}
+      <div className="px-8 pb-4">
+        <div className="flex items-center justify-between">
+          <button
+            onClick={handleBack}
+            className="bg-[#ffb800] text-black px-3 py-1 rounded hover:bg-[#e0a300] z-10"
+          >
+            ←
+          </button>
+          <div className="relative flex-1 mx-4 h-4 bg-gray-800 overflow-hidden rounded">
+            <div
+              key={current}
+              className="absolute inset-0"
+              style={{
+                background: "#ffb800",
+                animation: `progress ${interval}ms linear forwards`,
+              }}
+            />
+          </div>
+          <button
+            onClick={handleNext}
+            className="bg-[#ffb800] text-black px-3 py-1 rounded hover:bg-[#e0a300] z-10"
+          >
+            →
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/ui/player-stats-card.tsx
+++ b/components/ui/player-stats-card.tsx
@@ -1,13 +1,13 @@
-import Image from "next/image"
-import { Button } from "@/components/ui/button"
-import { cn } from "@/lib/utils"
+import Image from "next/image";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
 
 interface PlayerStatsCardProps {
-  name: string
-  position: string
-  ppg: number
-  avatar?: string
-  className?: string
+  name: string;
+  position: string;
+  ppg: number;
+  avatar?: string;
+  className?: string;
 }
 
 export function PlayerStatsCard({
@@ -18,13 +18,25 @@ export function PlayerStatsCard({
   className,
 }: PlayerStatsCardProps) {
   return (
-    <div className={cn("bg-black/90 backdrop-blur-sm p-6 rounded-lg border border-gray-800", className)}>
+    <div
+      className={cn(
+        "bg-black/90 backdrop-blur-sm p-6 rounded-lg border border-gray-800",
+        className
+      )}
+    >
       <div className="flex items-center gap-4 mb-6">
         <div className="relative w-16 h-16 rounded-full overflow-hidden border-2 border-[#ffb800]">
-          <Image src={avatar || "/placeholder.svg"} alt={name} fill className="object-cover" />
+          <Image
+            src={avatar || "/placeholder.svg"}
+            alt={name}
+            fill
+            className="object-cover"
+          />
         </div>
         <div>
-          <div className="text-[#ffb800] text-4xl font-bold">{ppg.toFixed(1)}</div>
+          <div className="text-[#ffb800] text-4xl font-bold">
+            {ppg.toFixed(1)}
+          </div>
           <div className="text-xs text-white">PPG RANK</div>
         </div>
       </div>
@@ -41,10 +53,12 @@ export function PlayerStatsCard({
         <p className="text-sm text-[#ffb800]">{position}</p>
       </div>
 
-      <Button variant="default" className="bg-[#ffb800] text-black hover:bg-[#e0a300] w-full font-bold">
+      <Button
+        variant="default"
+        className="bg-[#ffb800] text-black hover:bg-[#e0a300] w-full font-bold"
+      >
         VIEW STATS
       </Button>
     </div>
-  )
+  );
 }
-

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -1,3 +1,4 @@
+import { Player } from "@/components/rotating-top-players";
 export const SITE_NAME = "RISE";
 export const PRIMARY_COLOR = "#ffb800";
 
@@ -466,3 +467,27 @@ export const REVIEWS = Array.from({ length: 16 }).map((_, index) => ({
   date: "2 days ago",
   avatar: "/placeholder.svg?height=50&width=50",
 }));
+
+export const TOP3: Player[] = [
+  {
+    id: "1",
+    name: "CADE CUNNINGHAM",
+    position: "POINT GUARD",
+    ppg: 23.2,
+    avatar: "/partnerImages/nike.png",
+  },
+  {
+    id: "2",
+    name: "CONNOR DAVISON",
+    position: "CENTER",
+    ppg: 3.9,
+    avatar: "/partnerImages/nike.png",
+  },
+  {
+    id: "3",
+    name: "MOSTAPHA ALAHMAIR",
+    position: "SHOOTING GUARD",
+    ppg: 29.8,
+    avatar: "/partnerImages/nike.png",
+  },
+];

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -92,3 +92,12 @@ body {
     @apply bg-background text-foreground;
   }
 }
+
+@keyframes progress {
+  from {
+    width: 0%;
+  }
+  to {
+    width: 100%;
+  }
+}


### PR DESCRIPTION
# ✨ Changes Made

<!-- List what you changed, fixed, or added -->
- Added component so it rotates the top 3 players for points

---

# 🧠 Reason for Changes

<!-- Explain why this change was necessary -->
- Added this feature so instead of one player being showcased it is now the top 3
---

# 🧪 Testing Performed

<!-- Confirm what testing was done -->

- [ ✓ ] Frontend tested locally (`npm run dev`)
- [ ✓ ] No console errors (Frontend)

---



# 🔗 Related Trello Task

<!-- Link to the related Trello card -->
- https://trello.com/c/KmlHifj7/56-basketball-page-player-stats-rotating-top-player

---

# 🗒️ Notes for Reviewer 

<!-- Anything special to highlight, known issues, extra context, etc. -->
- Made it a component so we can reuse it anywhere on the website. We can also create a new component and copy and paste all the logic then change the styling to have rotating images of anything. 
