### PR TITLE
[Chore] Added all coaches button on basketball page

### DIFF
--- a/app/basketball/page.tsx
+++ b/app/basketball/page.tsx
@@ -224,6 +224,13 @@ export default function BasketballPage() {
                 and fun.
               </p>
             </ThreeDCard>
+            <Button
+              asChild
+              variant="outline"
+              className="mt-2 col-span-1 justify-self-center md:col-start-2 md:row-start-2 md:mt-0 md:self-center border-[#ffb800] text-[#ffb800] hover:bg-[#ffb800] hover:text-black hover:scale-105 transition-all shadow-lg"
+            >
+              <a href="/coaches">VIEW ALL COACHES</a>
+            </Button>
           </div>
         )}
       </SectionContainer>


### PR DESCRIPTION
# ✨ Changes Made

<!-- List what you changed, fixed, or added -->
- Added all coaches button to the coaches tab on the basketball page

---

# 🧠 Reason for Changes

<!-- Explain why this change was necessary -->
- Added this so users can view all the coaches at rise to see who will be coaching 
---

# 🧪 Testing Performed

<!-- Confirm what testing was done -->

- [ ✓ ] Frontend tested locally (`npm run dev`)
- [ ✓ ] No console errors (Frontend)

---

# 📸 Screenshots or Screen Recording

<!-- Attach screenshots or recordings if visual/UI changes were made -->
![image](https://github.com/user-attachments/assets/fa7e1c8d-43c8-4a17-a829-baaf3db789ba)

---

# 🔗 Related Trello Task

<!-- Link to the related Trello card -->
https://trello.com/c/b9LcDW75/135-add-button-on-basketball-page-for-all-coaches

---


