### PR TITLE
[Feature] Added barber gallery images from api

### DIFF
--- a/app/barber/page.tsx
+++ b/app/barber/page.tsx
@@ -11,6 +11,7 @@ import { ThreeDCard } from "@/components/ui/3d-card";
 import { AnimatedText } from "@/components/ui/animated-text";
 import PartnerLogos from "@/components/partner-logos";
 import { BARBER_SERVICES } from "@/lib/constants";
+import { HaircutGallerySection } from "@/components/haircutGallerySection";
 
 export default function BarberPage() {
   return (
@@ -182,26 +183,7 @@ export default function BarberPage() {
       <SectionContainer>
         <SectionHeading title="Haircut Gallery" centered />
 
-        <div className="grid grid-cols-2 md:grid-cols-5 gap-4">
-          {Array.from({ length: 10 }).map((_, index) => (
-            <div
-              key={index}
-              className="relative h-[150px] overflow-hidden rounded-lg border border-gray-800 group hover:border-[#ffb800]/50 transition-all duration-300 shadow-md"
-            >
-              <img
-                src={`https://source.unsplash.com/random/300x300?haircut,barber&sig=${index}`}
-                alt={`Haircut style ${index + 1}`}
-                className="object-cover h-full w-full transition-transform duration-500 group-hover:scale-110"
-              />
-              <div className="absolute inset-0 bg-gradient-to-t from-black/70 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
-              <div className="absolute bottom-0 left-0 right-0 p-2 bg-black/60 transform translate-y-full group-hover:translate-y-0 transition-transform duration-300">
-                <p className="text-xs text-white font-medium">
-                  Style #{index + 1}
-                </p>
-              </div>
-            </div>
-          ))}
-        </div>
+        <HaircutGallerySection limit={10} />
 
         <div className="text-center mt-8">
           <Button

--- a/components/haircutGallerySection.tsx
+++ b/components/haircutGallerySection.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { useHaircuts } from "@/hooks/useHaircuts";
+import { cn } from "@/lib/utils";
+
+/**
+ * Props for HaircutGallerySection component.
+ * @param limit     Maximum number of images to display (optional).
+ * @param className Additional CSS classes for the wrapper (optional).
+ */
+interface HaircutGallerySectionProps {
+  limit?: number;
+  className?: string;
+}
+
+/**
+ * HaircutGallerySection:
+ * Fetches haircut image URLs from the API and displays them
+ * in a responsive grid (2 columns on mobile up to 5 on desktop).
+ */
+export function HaircutGallerySection({
+  limit,
+  className,
+}: HaircutGallerySectionProps) {
+  // Invoke the hook to load images and track loading/error states
+  const { images, loading, error } = useHaircuts(limit);
+
+  // While data is loading, show a placeholder message
+  if (loading) {
+    return <p>Loading gallery…</p>;
+  }
+
+  // If an error occurred, display it in red
+  if (error) {
+    return <p className="text-red-500">Error: {error}</p>;
+  }
+
+  // Once images are fetched, render the grid
+  return (
+    // Section wrapper with vertical spacing and any custom classes
+    <section className={cn("space-y-4", className)}>
+      {/* Grid: 2 columns by default, expanding to 5 on md+ breakpoints */}
+      <div className="grid grid-cols-2 md:grid-cols-5 gap-4">
+        {images.map((src, index) => (
+          // Each image card uses group-hover utilities for animation
+          <div
+            key={index}
+            className="relative h-[150px] overflow-hidden rounded-lg border border-gray-800 group hover:border-[#ffb800]/50 transition-all duration-300 shadow-md"
+          >
+            {/* Haircut image with zoom-on-hover */}
+            <img
+              src={src}
+              alt={`Haircut style ${index + 1}`}
+              className="object-cover h-full w-full transition-transform duration-500 group-hover:scale-110"
+            />
+
+            {/* Gradient overlay fades in on hover to improve contrast */}
+            <div className="absolute inset-0 bg-gradient-to-t from-black/70 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
+
+            {/* Caption slides up on hover */}
+            <div className="absolute bottom-0 left-0 right-0 p-2 bg-black/60 transform translate-y-full group-hover:translate-y-0 transition-transform duration-300">
+              <p className="text-xs text-white font-medium">
+                Style #{index + 1}
+              </p>
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/hooks/useHaircuts.ts
+++ b/hooks/useHaircuts.ts
@@ -1,0 +1,35 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { getHaircuts } from "@/services/haircuts";
+
+/**
+ * React hook to fetch haircut image URLs.
+ *
+ * @param limit Optional maximum number of images to return.
+ * @returns An object { images, loading, error }
+ */
+export function useHaircuts(limit?: number) {
+  const [images, setImages] = useState<string[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string>();
+
+  useEffect(() => {
+    setLoading(true);
+    setError(undefined);
+
+    getHaircuts()
+      .then((list) => {
+        // optionally slice to the requested limit
+        setImages(limit ? list.slice(0, limit) : list);
+      })
+      .catch((err) => {
+        setError(err.message);
+      })
+      .finally(() => {
+        setLoading(false);
+      });
+  }, [limit]);
+
+  return { images, loading, error };
+}

--- a/services/haircuts.ts
+++ b/services/haircuts.ts
@@ -1,0 +1,18 @@
+import getValue from "@/configs/constants";
+
+/**
+ * Fetches the list of haircut image URLs from the API.
+ *
+ * Endpoint: GET `${API_BASE}haircuts`
+ *
+ * @returns Promise resolving to an array of image‑URL strings.
+ * @throws Error if the network request fails.
+ */
+export async function getHaircuts(): Promise<string[]> {
+  const res = await fetch(`${getValue("API")}haircuts`);
+  if (!res.ok) {
+    throw new Error(`Failed to fetch haircuts: ${res.statusText}`);
+  }
+  // the API returns an array of strings
+  return res.json();
+}


### PR DESCRIPTION
# ✨ Changes Made

<!-- List what you changed, fixed, or added -->
- Added haircutgallarysection component
- Added useHaircuts hook
- Added haircuts service
- Changed page components being called
---

# 🧠 Reason for Changes

<!-- Explain why this change was necessary -->
- Introducing a new HaircutGallerySection component that handles layout and rendering
- Creating a useHaircuts hook to encapsulate the fetch, loading, and error logic
- Implementing a haircuts service that calls the /haircuts endpoint and returns the image URLs
- Updating the page to replace the old hard‑coded gallery with the new HaircutGallerySection component
---

# 🧪 Testing Performed

<!-- Confirm what testing was done -->

- [X] Frontend tested locally (`npm run dev`)
- [X] No console errors (Frontend)

---

# 📸 Screenshots or Screen Recording

<!-- Attach screenshots or recordings if visual/UI changes were made -->
![WhatsApp Image 2025-05-15 at 15 13 53_056d2d96](https://github.com/user-attachments/assets/a786977f-2495-43f1-8be4-f6a87661acaf)

---

# 🔗 Related Trello Task

<!-- Link to the related Trello card -->
https://trello.com/c/KO9XCpMy/24-call-barber-get-api-for-website

---


