### PR TITLE
[Bugfix] Both team logos displayed instead of one

### DIFF
--- a/components/ui/game-card.tsx
+++ b/components/ui/game-card.tsx
@@ -23,12 +23,14 @@ interface GameCardProps {
   date: string;
   /** Formatted time string (e.g. "9:23 PM") */
   time: string;
-  /** Optional URL for the game’s image or logo */
-  image?: string;
   /** Additional CSS classes to apply to the card container */
   className?: string;
   /** Index used to stagger the animation delay */
   index?: number;
+  /** URL for the team/logo image  */
+  homeLogo?: string;
+  /** URL for the team/logo image  */
+  awayLogo?: string;
 }
 
 /**
@@ -51,7 +53,8 @@ export function GameCard({
   team2,
   date,
   time,
-  image = "/placeholder.svg?height=200&width=300",
+  homeLogo,
+  awayLogo,
   className,
   index = 0,
 }: GameCardProps) {
@@ -71,16 +74,29 @@ export function GameCard({
       )}
     >
       {/* Image container with hover zoom and gradient overlay */}
-      <div className="relative h-32 overflow-hidden group">
-        <Image
-          src={image}
-          alt={`${team1} vs ${team2}`}
-          fill
-          className="object-cover transition-transform duration-700 group-hover:scale-110"
-        />
-        {/* Dark gradient to improve text contrast */}
+      <div className="relative h-32 overflow-hidden group grid grid-cols-2">
+        {homeLogo && (
+          <div className="relative w-full h-full">
+            <Image
+              src={homeLogo}
+              alt={`${team1} logo`}
+              fill
+              className="object-cover transition-transform duration-700 group-hover:scale-110"
+            />
+          </div>
+        )}
+        {awayLogo && (
+          <div className="relative w-full h-full">
+            <Image
+              src={awayLogo}
+              alt={`${team2} logo`}
+              fill
+              className="object-cover transition-transform duration-700 group-hover:scale-110"
+            />
+          </div>
+        )}
+        {/* retain your gradient & badge */}
         <div className="absolute inset-0 bg-gradient-to-t from-black/80 to-transparent"></div>
-        {/* Badge showing either "GAME {rank}" or fallback to raw ID */}
         <div className="absolute top-2 right-2 bg-[#ffb800] text-black text-xs font-bold px-2 py-1 rounded shadow-md">
           GAME {rank ?? id}
         </div>

--- a/components/ui/game-grid.tsx
+++ b/components/ui/game-grid.tsx
@@ -15,8 +15,10 @@ interface Game {
   date: string;
   /** Formatted time string (e.g. "9:23 PM") */
   time: string;
-  /** Optional URL for a team logo or placeholder image */
-  image?: string;
+  /** URL for the home team logo */
+  homeLogo?: string;
+  /** URL for the away team logo */
+  awayLogo?: string;
 }
 
 //
@@ -76,7 +78,8 @@ export function GameGrid({
           team2={game.team2}
           date={game.date}
           time={game.time}
-          image={game.image}
+          homeLogo={game.homeLogo}
+          awayLogo={game.awayLogo}
         />
       ))}
     </div>

--- a/services/games.ts
+++ b/services/games.ts
@@ -26,8 +26,10 @@ export interface Game {
   date: string;
   /** Formatted display time (e.g. “9:23 PM”) */
   time: string;
-  /** Optional logo URL */
-  image?: string;
+  /** home logo URL */
+  homeLogo?: string;
+  /** away logo URL */
+  awayLogo?: string;
 }
 
 /**
@@ -70,7 +72,8 @@ export async function getGames(limit?: number): Promise<Game[]> {
         hour: "numeric",
         minute: "2-digit",
       }),
-      image: g.home_team_logo_url || undefined,
+      homeLogo: g.home_team_logo_url,
+      awayLogo: g.away_team_logo_url,
     };
   });
 }


### PR DESCRIPTION
# ✨ Changes Made

<!-- List what you changed, fixed, or added -->
- Added both images in game card
- added home logo and away logo to, game-grid and games.ts service

---

# 🧠 Reason for Changes

<!-- Explain why this change was necessary -->
- GameCard update: Render both the home and away team logos side‑by‑side in the card’s header so each matchup shows both teams visually.
- Data and grid enhancements: Extended the games.ts service to include homeLogo and awayLogo fields, and updated the GameGrid component to pass those two logo URLs into each GameCard.
---

# 🧪 Testing Performed

<!-- Confirm what testing was done -->

- [X] Frontend tested locally (`npm run dev`)
- [X] No console errors (Frontend)

---

# 📸 Screenshots or Screen Recording

<!-- Attach screenshots or recordings if visual/UI changes were made -->
![WhatsApp Image 2025-05-15 at 16 24 35_1ca996d9](https://github.com/user-attachments/assets/17147b8b-ef5c-4ef3-9ec7-528ee1551733)

---

# 🔗 Related Trello Task

<!-- Link to the related Trello card -->
https://trello.com/c/mMwOvaH5/53-basketball-page-all-games-images

---
