### PR TITLE
[Chore] Fixed Join Now buttons, Deleted some Learn More buttons

### DIFF
--- a/app/basketball/page.tsx
+++ b/app/basketball/page.tsx
@@ -19,6 +19,7 @@ import { TopPlayersSection } from "@/components/topPlayersSection";
 import { RotatingTopPlayers } from "@/components/rotatingTopThree";
 import { UpcomingGamesSection } from "@/components/gamesSection";
 import ScheduleCalendar from "@/components/scheduleCalendar";
+import Link from "next/link";
 
 export default function BasketballPage() {
   const { scrollYProgress } = useScroll();
@@ -330,13 +331,7 @@ export default function BasketballPage() {
                 variant="default"
                 className="bg-[#ffb800] text-black hover:bg-[#e0a300] hover:scale-105 transition-all shadow-lg"
               >
-                <a href="/join">JOIN NOW</a>
-              </Button>
-              <Button
-                variant="link"
-                className="text-white hover:text-[#ffb800] px-0 hover:scale-105 transition-all p-4"
-              >
-                <a href="/learn-more">LEARN MORE</a>
+                <Link href="/allmemberships">JOIN NOW</Link>
               </Button>
             </motion.div>
           </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -232,14 +232,7 @@ export default function Home() {
                 variant="default"
                 className="bg-[#ffb800] text-black hover:bg-[#e0a300] hover:scale-105 transition-all shadow-lg"
               >
-                <a href="/join">JOIN NOW</a>
-              </Button>
-              <Button
-                asChild
-                variant="link"
-                className="text-white hover:text-[#ffb800] px-0 hover:scale-105 transition-all"
-              >
-                <a href="/learn-more">LEARN MORE</a>
+                <a href="/allmemberships">JOIN NOW</a>
               </Button>
             </motion.div>
           </div>

--- a/app/performance/page.tsx
+++ b/app/performance/page.tsx
@@ -13,6 +13,7 @@ import PartnerLogos from "@/components/partner-logos";
 import { MEMBERSHIP_PLANS, PERFORMANCE_FEATURES } from "@/lib/constants";
 import { Button } from "@/components/ui/button";
 import { ChevronDown } from "lucide-react";
+import Link from "next/link";
 
 export default function PerformancePage() {
   const { scrollYProgress } = useScroll();
@@ -66,13 +67,13 @@ export default function PerformancePage() {
       <SectionContainer id="why-rise" className="bg-[#111]">
         <div className="grid grid-cols-1 md:grid-cols-2 gap-12 items-center">
           <div className="relative h-[400px]">
-            <ThreeDCard className="h-full">
+            <div className="h-full">
               <img
                 src="/placeholder.svg?height=600&width=800"
                 alt="Fitness training"
                 className="object-cover rounded-lg h-full w-full"
               />
-            </ThreeDCard>
+            </div>
           </div>
           <div>
             <SectionHeading
@@ -185,13 +186,7 @@ export default function PerformancePage() {
                 variant="default"
                 className="bg-[#ffb800] text-black hover:bg-[#e0a300] hover:scale-105 transition-all shadow-lg"
               >
-                JOIN NOW
-              </Button>
-              <Button
-                variant="link"
-                className="text-white hover:text-[#ffb800] px-0 hover:scale-105 transition-all"
-              >
-                Learn More
+                <Link href="/allmemberships">JOIN NOW</Link>
               </Button>
             </motion.div>
           </div>

--- a/components/ui/membership-card.tsx
+++ b/components/ui/membership-card.tsx
@@ -4,8 +4,10 @@ import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { Check } from "lucide-react";
 import { motion } from "framer-motion";
+import Link from "next/link";
 
 interface MembershipCardProps {
+  id: string;
   featured?: boolean;
   badge?: string;
   title: string;
@@ -13,15 +15,14 @@ interface MembershipCardProps {
   period: string;
   description: string;
   features: string[];
-  ctaText: string;
-  learnMoreText: string;
-  onCtaClick?: () => void;
-  onLearnMoreClick?: () => void;
+  ctaText?: string;
+  learnMoreText?: string;
   className?: string;
   index?: number;
 }
 
 export function MembershipCard({
+  id,
   featured = false,
   badge,
   title,
@@ -31,8 +32,6 @@ export function MembershipCard({
   features,
   ctaText,
   learnMoreText,
-  onCtaClick,
-  onLearnMoreClick,
   className,
   index = 0,
 }: MembershipCardProps) {
@@ -65,10 +64,10 @@ export function MembershipCard({
                 featured ? "text-black" : "text-white"
               )}
             >
-              {title.split("<br/>").map((part, i) => (
+              {title.split("<br/>").map((part, i, arr) => (
                 <span key={i}>
                   {part}
-                  {i < title.split("<br/>").length - 1 && <br />}
+                  {i < arr.length - 1 && <br />}
                 </span>
               ))}
             </h3>
@@ -100,9 +99,9 @@ export function MembershipCard({
         </p>
 
         <ul className="space-y-3 mb-6">
-          {features.map((feature, index) => (
+          {features.map((feature, idx) => (
             <li
-              key={index}
+              key={idx}
               className={cn(
                 "flex items-center text-sm",
                 featured ? "text-black" : "text-white"
@@ -137,19 +136,19 @@ export function MembershipCard({
                 : "border-[#ffb800] text-[#ffb800] hover:bg-[#ffb800]/10 hover:border-[#ffb800]"
             )}
           >
-            <a href="/learn-more">LEARN MORE</a>
+            <Link href="/allmemberships">VIEW MORE</Link>
           </Button>
           <Button
             asChild
             variant="default"
             className={cn(
-              "transition-all duration-300 hover:scale-105 shadow-lg font-bold",
+              "w-full transition-all duration-300 hover:scale-105 shadow-lg font-bold",
               featured
                 ? "bg-black text-white hover:bg-gray-800"
                 : "bg-[#ffb800] text-black hover:bg-[#e0a300]"
             )}
           >
-            <a href="/join">JOIN NOW</a>
+            <Link href={`/memberships/${id}`}>JOIN NOW</Link>
           </Button>
         </div>
       </div>

--- a/components/ui/membership-grid.tsx
+++ b/components/ui/membership-grid.tsx
@@ -35,6 +35,7 @@ export function MembershipGrid({
     <div className={cn(`grid ${gridCols[columns]} gap-6`, className)}>
       {plans.map((plan) => (
         <MembershipCard
+          id={plan.id}
           key={plan.id}
           featured={plan.featured}
           badge={plan.badge}


### PR DESCRIPTION
# ✨ Changes Made

<!-- List what you changed, fixed, or added -->
- Changed routes for join now buttons
- Deleted learn more buttons that were unused
- Switched from anchors to Link
- Fixed membership button

---

# 🧠 Reason for Changes

<!-- Explain why this change was necessary -->
- Changed the route so users will go to the all memberships page
- Deleted learn more buttons that were being unused
- Switched to Link  for next.js optimization 
- Fixed membership button so the join now will take you to the membership id page, view more will take you to the all membership page 
---

# 🧪 Testing Performed

<!-- Confirm what testing was done -->

- [X] Frontend tested locally (`npm run dev`)
- [X] No console errors (Frontend)

---

# 🔗 Related Trello Task

<!-- Link to the related Trello card -->
- https://trello.com/c/Lv2IMGNv/150-change-join-buttons
- https://trello.com/c/Q1kCaTVP/157-learn-more-button-styling

---

# 🗒️ Notes for Reviewer

<!-- Anything special to highlight, known issues, extra context, etc. -->
- Two trello cards were completed. Was going to style the learn more buttons but we decided to delete them.
