### PR TITLE
[Chore] Coaches page APIs display

### DIFF
--- a/app/basketball/page.tsx
+++ b/app/basketball/page.tsx
@@ -20,6 +20,7 @@ import { RotatingTopPlayers } from "@/components/rotatingTopThree";
 import { UpcomingGamesSection } from "@/components/gamesSection";
 import ScheduleCalendar from "@/components/scheduleCalendar";
 import Link from "next/link";
+import CoachesSection from "@/components/coachesSection";
 
 export default function BasketballPage() {
   const { scrollYProgress } = useScroll();
@@ -83,7 +84,7 @@ export default function BasketballPage() {
       </ParallaxSection>
 
       {/* Program Tabs */}
-      <SectionContainer id="programs" className="bg-[#111]">
+      <SectionContainer id="programs" className="">
         <SectionHeading title="BASKETBALL INFORMATION" centered />
 
         <div className="mb-8 max-w-3xl mx-auto">
@@ -149,61 +150,21 @@ export default function BasketballPage() {
         )}
 
         {activeTab === "coaches" && (
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-            <ThreeDCard className="bg-black/50 p-6 rounded-lg text-center">
-              <div className="w-24 h-24 rounded-full bg-gray-700 mx-auto mb-4 overflow-hidden">
-                <img
-                  src="/placeholder.svg?height=100&width=100"
-                  alt="Coach"
-                  className="w-full h-full object-cover"
-                />
-              </div>
-              <h3 className="text-xl font-bold mb-1">Coach Mike</h3>
-              <p className="text-[#ffb800] mb-2">Head Coach</p>
-              <p className="text-sm">
-                Former professional player with 15+ years of coaching
-                experience.
-              </p>
-            </ThreeDCard>
+          // use vertical spacing between the grid and the button
+          <div className="space-y-6">
+            {/* your 3‑coach grid */}
+            <CoachesSection ids={[1, 2, 3]} showHeadings={false} />
 
-            <ThreeDCard className="bg-black/50 p-6 rounded-lg text-center">
-              <div className="w-24 h-24 rounded-full bg-gray-700 mx-auto mb-4 overflow-hidden">
-                <img
-                  src="/placeholder.svg?height=100&width=100"
-                  alt="Coach"
-                  className="w-full h-full object-cover"
-                />
-              </div>
-              <h3 className="text-xl font-bold mb-1">Coach Sarah</h3>
-              <p className="text-[#ffb800] mb-2">Skills Development</p>
-              <p className="text-sm">
-                NCAA Division I player specializing in shooting and ball
-                handling.
-              </p>
-            </ThreeDCard>
-
-            <ThreeDCard className="bg-black/50 p-6 rounded-lg text-center">
-              <div className="w-24 h-24 rounded-full bg-gray-700 mx-auto mb-4 overflow-hidden">
-                <img
-                  src="/placeholder.svg?height=100&width=100"
-                  alt="Coach"
-                  className="w-full h-full object-cover"
-                />
-              </div>
-              <h3 className="text-xl font-bold mb-1">Coach James</h3>
-              <p className="text-[#ffb800] mb-2">Youth Coach</p>
-              <p className="text-sm">
-                Specializes in youth development with a focus on fundamentals
-                and fun.
-              </p>
-            </ThreeDCard>
-            <Button
-              asChild
-              variant="outline"
-              className="mt-2 col-span-1 justify-self-center md:col-start-2 md:row-start-2 md:mt-0 md:self-center border-[#ffb800] text-[#ffb800] hover:bg-[#ffb800] hover:text-black hover:scale-105 transition-all shadow-lg"
-            >
-              <a href="/coaches">VIEW ALL COACHES</a>
-            </Button>
+            {/* wrap the button in a flex container to center it */}
+            <div className="flex justify-center">
+              <Button
+                asChild
+                variant="outline"
+                className="border-[#ffb800] text-[#ffb800] hover:bg-[#ffb800] hover:text-black hover:scale-105 transition-all shadow-lg"
+              >
+                <a href="/coaches">VIEW ALL COACHES</a>
+              </Button>
+            </div>
           </div>
         )}
       </SectionContainer>

--- a/app/basketball/page.tsx
+++ b/app/basketball/page.tsx
@@ -153,7 +153,14 @@ export default function BasketballPage() {
           // use vertical spacing between the grid and the button
           <div className="space-y-6">
             {/* your 3‑coach grid */}
-            <CoachesSection ids={[1, 2, 3]} showHeadings={false} />
+            <CoachesSection
+              ids={[
+                "151453fe-b666-44f4-b4da-c8a216a7e5b3",
+                "f58fe0c7-b5ad-4433-9ec0-84d64863dbf8",
+                "bf62b2a5-71bb-46fe-91fe-a44e4e65848b",
+              ]}
+              showHeadings={false}
+            />
 
             {/* wrap the button in a flex container to center it */}
             <div className="flex justify-center">

--- a/app/coaches/page.tsx
+++ b/app/coaches/page.tsx
@@ -4,6 +4,7 @@ import { SectionContainer } from "@/components/ui/section-container";
 import { SectionHeading } from "@/components/ui/section-heading";
 import { ParallaxSection } from "@/components/ui/parallax-section";
 import { AnimatedText } from "@/components/ui/animated-text";
+import CoachesSection from "@/components/coachesSection";
 
 export default function CoachesPage() {
   return (
@@ -31,117 +32,7 @@ export default function CoachesPage() {
         </SectionContainer>
       </ParallaxSection>
       {/* BASKETBALL COACHES SECTION */}
-      <SectionContainer
-        id="basketballcoaches"
-        className="py-16"
-        animate={false}
-      >
-        <SectionHeading
-          title="BASKETBALL COACHES"
-          centered
-          animate={false}
-          className="py-16"
-        />
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-          <div className="bg-black/50 p-6 rounded-lg text-center">
-            <div className="w-24 h-24 rounded-full bg-gray-700 mx-auto mb-4 overflow-hidden">
-              <img
-                src="/placeholder.svg?height=100&width=100"
-                alt="Coach"
-                className="w-full h-full object-cover"
-              />
-            </div>
-            <h3 className="text-xl font-bold mb-1">Coach Mike</h3>
-            <p className="text-[#ffb800] mb-2">Head Coach</p>
-            <p className="text-sm">
-              Former professional player with 15+ years of coaching experience.
-            </p>
-          </div>
-
-          <div className="bg-black/50 p-6 rounded-lg text-center">
-            <div className="w-24 h-24 rounded-full bg-gray-700 mx-auto mb-4 overflow-hidden">
-              <img
-                src="/placeholder.svg?height=100&width=100"
-                alt="Coach"
-                className="w-full h-full object-cover"
-              />
-            </div>
-            <h3 className="text-xl font-bold mb-1">Coach Sarah</h3>
-            <p className="text-[#ffb800] mb-2">Skills Development</p>
-            <p className="text-sm">
-              NCAA Division I player specializing in shooting and ball handling.
-            </p>
-          </div>
-
-          <div className="bg-black/50 p-6 rounded-lg text-center">
-            <div className="w-24 h-24 rounded-full bg-gray-700 mx-auto mb-4 overflow-hidden">
-              <img
-                src="/placeholder.svg?height=100&width=100"
-                alt="Coach"
-                className="w-full h-full object-cover"
-              />
-            </div>
-            <h3 className="text-xl font-bold mb-1">Coach James</h3>
-            <p className="text-[#ffb800] mb-2">Youth Coach</p>
-            <p className="text-sm">
-              Specializes in youth development with a focus on fundamentals and
-              fun.
-            </p>
-          </div>
-        </div>
-      </SectionContainer>
-
-      {/* PERFORMANCE COACHES SECTION */}
-      <SectionContainer id="performancecoaches" className="py-16 bg-[#111]">
-        <SectionHeading title="PERFORMANCE COACHES" centered />
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-          <div className="bg-black/50 p-6 rounded-lg text-center">
-            <div className="w-24 h-24 rounded-full bg-gray-700 mx-auto mb-4 overflow-hidden">
-              <img
-                src="/placeholder.svg?height=100&width=100"
-                alt="Coach"
-                className="w-full h-full object-cover"
-              />
-            </div>
-            <h3 className="text-xl font-bold mb-1">Coach Mike</h3>
-            <p className="text-[#ffb800] mb-2">Head Coach</p>
-            <p className="text-sm">
-              Former professional player with 15+ years of coaching experience.
-            </p>
-          </div>
-
-          <div className="bg-black/50 p-6 rounded-lg text-center">
-            <div className="w-24 h-24 rounded-full bg-gray-700 mx-auto mb-4 overflow-hidden">
-              <img
-                src="/placeholder.svg?height=100&width=100"
-                alt="Coach"
-                className="w-full h-full object-cover"
-              />
-            </div>
-            <h3 className="text-xl font-bold mb-1">Coach Sarah</h3>
-            <p className="text-[#ffb800] mb-2">Skills Development</p>
-            <p className="text-sm">
-              NCAA Division I player specializing in shooting and ball handling.
-            </p>
-          </div>
-
-          <div className="bg-black/50 p-6 rounded-lg text-center">
-            <div className="w-24 h-24 rounded-full bg-gray-700 mx-auto mb-4 overflow-hidden">
-              <img
-                src="/placeholder.svg?height=100&width=100"
-                alt="Coach"
-                className="w-full h-full object-cover"
-              />
-            </div>
-            <h3 className="text-xl font-bold mb-1">Coach James</h3>
-            <p className="text-[#ffb800] mb-2">Youth Coach</p>
-            <p className="text-sm">
-              Specializes in youth development with a focus on fundamentals and
-              fun.
-            </p>
-          </div>
-        </div>
-      </SectionContainer>
+      <CoachesSection />
     </div>
   );
 }

--- a/components/coachesSection.tsx
+++ b/components/coachesSection.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Coach, getCoaches } from "@/services/coaches"; // adjust path if needed
+import { SectionContainer } from "@/components/ui/section-container";
+import { SectionHeading } from "@/components/ui/section-heading";
+
+interface CoachesSectionProps {
+  /**
+   * Optional list of coach IDs to display.
+   * If provided, only coaches with matching IDs (in this order) will render.
+   * If omitted, all fetched coaches are shown.
+   */
+  ids?: number[];
+  showHeadings?: boolean;
+}
+
+export default function CoachesSection({
+  ids,
+  showHeadings = true,
+}: CoachesSectionProps) {
+  const [coaches, setCoaches] = useState<Coach[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string>("");
+
+  useEffect(() => {
+    getCoaches()
+      .then((data) => setCoaches(data))
+      .catch((err) => setError(err.message))
+      .finally(() => setLoading(false));
+  }, []);
+
+  if (loading) return <p>Loading coaches…</p>;
+  if (error) return <p className="text-red-500">Error: {error}</p>;
+
+  // Determine which coaches to display
+  const toDisplay: Coach[] =
+    Array.isArray(ids) && ids.length > 0
+      ? // map over ids to preserve order, filter out any missing
+        ids
+          .map((id) => coaches.find((c) => c.id === id))
+          .filter((c): c is Coach => Boolean(c))
+      : coaches;
+
+  return (
+    <SectionContainer id="basketballcoaches" className="py-16" animate={false}>
+      {showHeadings && (
+        <SectionHeading
+          title="MEET THE COACHES"
+          centered
+          animate={false}
+          className="py-16"
+        />
+      )}
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+        {toDisplay.map((coach) => (
+          <div
+            key={coach.id}
+            className="bg-black/50 p-6 rounded-lg text-center"
+          >
+            <div className="w-24 h-24 rounded-full bg-gray-700 mx-auto mb-4 overflow-hidden">
+              <img
+                src={coach.photo_url}
+                alt={`${coach.first_name} ${coach.last_name}`}
+                className="w-full h-full object-cover"
+              />
+            </div>
+            <h3 className="text-xl font-bold mb-1">
+              {coach.first_name} {coach.last_name}
+            </h3>
+            <p className="text-[#ffb800] mb-2 first-letter:uppercase">
+              {coach.role_name}
+            </p>
+          </div>
+        ))}
+      </div>
+    </SectionContainer>
+  );
+}

--- a/components/coachesSection.tsx
+++ b/components/coachesSection.tsx
@@ -11,7 +11,7 @@ interface CoachesSectionProps {
    * If provided, only coaches with matching IDs (in this order) will render.
    * If omitted, all fetched coaches are shown.
    */
-  ids?: number[];
+  ids?: string[];
   showHeadings?: boolean;
 }
 

--- a/services/coaches.ts
+++ b/services/coaches.ts
@@ -1,5 +1,5 @@
 export interface Coach {
-  id: number;
+  id: string;
   first_name: string;
   last_name: string;
   role_name: string;
@@ -17,8 +17,8 @@ export async function getCoaches(): Promise<Coach[]> {
   }
 
   const data: Coach[] = await res.json();
-  return data.map((c, idx) => ({
-    id: idx + 1,
+  return data.map((c) => ({
+    id: c.id,
     first_name: c.first_name ?? "",
     last_name: c.last_name ?? "",
     role_name: c.role_name ?? "",

--- a/services/coaches.ts
+++ b/services/coaches.ts
@@ -1,0 +1,27 @@
+export interface Coach {
+  id: number;
+  first_name: string;
+  last_name: string;
+  role_name: string;
+  photo_url: string;
+}
+
+const apiBaseUrl = process.env.NEXT_PUBLIC_API_BASE_URL!;
+
+export async function getCoaches(): Promise<Coach[]> {
+  const url = `${apiBaseUrl}/staffs?role=coach`;
+
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error(`Failed to fetch coaches: ${res.statusText}`);
+  }
+
+  const data: Coach[] = await res.json();
+  return data.map((c, idx) => ({
+    id: idx + 1,
+    first_name: c.first_name ?? "",
+    last_name: c.last_name ?? "",
+    role_name: c.role_name ?? "",
+    photo_url: c.photo_url ?? "",
+  }));
+}


### PR DESCRIPTION
# ✨ Changes Made

<!-- List what you changed, fixed, or added -->
- Added coaches service
- Called coach section component on the basketball page
- Called coach section component on all coaches page 
- Created coaches section component

---

# 🧠 Reason for Changes

<!-- Explain why this change was necessary -->
- Added the service to use with the API route to display coaches instead of hard coded data
- Called component on basketball page to display coaches from the backend, limit of 3 with specific IDs
- Called the component to display all the coaches currently working at RISE
- Created the coaches Section component so we can display and show all the Coaches to the Users 
---

# 🧪 Testing Performed

<!-- Confirm what testing was done -->

- [X] Frontend tested locally (`npm run dev`)
- [X] No console errors (Frontend)

---



# 🔗 Related Trello Task

<!-- Link to the related Trello card -->
<!-- Link to the related Trello card -->
- https://trello.com/c/5DFeCRBA/26-call-staff-get-api-for-website
- https://trello.com/c/7sKXjfD0/49-basketball-page-basketball-information-add-images-for-coaches

---

# 🗒️ Notes for Reviewer 

<!-- Anything special to highlight, known issues, extra context, etc. -->
- Adding images for coaches as we go so two Trello cards completed
