### PR TITLE
[chore] routed membership drop downs to go to glofox

### DIFF
--- a/components/header.tsx
+++ b/components/header.tsx
@@ -51,11 +51,11 @@ export default function Header() {
 
   const dropdowns: Record<string, { href: string; label: string }[]> = {
     "/basketball": [
-      { href: "/allmemberships", label: "Memberships" },
+      { href: "https://app.glofox.com/portal/#/branch/66464503a11addded10584e5/memberships", label: "Memberships" },
       { href: "/coaches", label: "Coaches" },
       { href: "/games", label: "Games" },
     ],
-    "/performance": [{ href: "/allmemberships", label: "Memberships" }],
+    "/performance": [{ href: "https://app.glofox.com/portal/#/branch/66464503a11addded10584e5/memberships", label: "Memberships" }],
     "/contact": [
       { href: "/contact", label: "Contact Us" },
       { href: "/reviews", label: "Reviews" },


### PR DESCRIPTION

# ✨ Changes Made

<!-- List what you changed, fixed, or added -->
-  Changed the drop down memberships to go to glofox instead of /allmemberships
- 
- 

---

# 🧠 Reason for Changes

we will change it once the admin panel is set up

---

# 🧪 Testing Performed

<!-- Confirm what testing was done -->

- [X] Frontend tested locally (`npm run dev`)
- [ ] Mobile App tested via Expo / emulator
- [ ] Backend APIs tested via Postman
- [X] No console errors (Frontend)
- [ ] No server errors (Backend)
- [ ] Mobile app builds successfully (if applicable)

---


