### PR TITLE
Rename Membership to Registration across the website

### DIFF
--- a/app/basketball/page.tsx
+++ b/app/basketball/page.tsx
@@ -444,7 +444,7 @@ export default function BasketballPage() {
       </ParallaxSection> */}
 
       {/* Basketball Memberships */}
-      <BasketballMembershipsSection showHeading headingTitle="Basketball Memberships" />
+      <BasketballMembershipsSection showHeading headingTitle="Basketball Registrations" />
 
       {/* Gallery */}
       <SectionContainer>

--- a/app/cancelled/page.tsx
+++ b/app/cancelled/page.tsx
@@ -44,7 +44,7 @@ export default function CancelledPage() {
                 Return to Homepage
               </Button>
             </Link>
-            <Link href="/memberships">
+            <Link href="/registrations">
               <Button className="flex items-center gap-2 bg-[#ffb800] text-black hover:bg-[#e0a300] hover:scale-105 transition-all shadow-lg">
                 <RefreshCw className="w-4 h-4" />
                 Try Again

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -14,7 +14,7 @@ const inter = Inter({ subsets: ["latin"] });
 export const metadata: Metadata = {
   title: `${SITE_NAME} - Basketball, Performance, Academy & More`,
   description:
-    "Year-round basketball membership for all ages, fitness training, and more.",
+    "Year-round basketball registration for all ages, fitness training, and more.",
   metadataBase: new URL("https://risesportscomplex.com"),
   icons: {
     icon: "/favicon.ico",
@@ -24,7 +24,7 @@ export const metadata: Metadata = {
   openGraph: {
     title: `${SITE_NAME} - Basketball, Performance, Academy & More`,
     description:
-      "Year-round basketball membership for all ages, fitness training, and more.",
+      "Year-round basketball registration for all ages, fitness training, and more.",
     type: "website",
     locale: "en_US",
     siteName: SITE_NAME,

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -270,7 +270,7 @@ export default function Home() {
           </motion.div>
           <div>
             <SectionHeading
-              title="RISE PERFORMANCE MEMBERSHIP"
+              title="RISE PERFORMANCE REGISTRATION"
               subtitle="Train, Play, and Get in the Best Shape of Your Life"
             />
             <motion.p
@@ -403,7 +403,7 @@ export default function Home() {
       </SectionContainer>
 
       {/* Memberships Section */}
-      <MembershipsSection showHeading headingTitle="Memberships" containerId="memberships" />
+      <MembershipsSection showHeading headingTitle="Registrations" containerId="memberships" />
 
       {/* Compare Plans */}
       <ParallaxSection
@@ -424,7 +424,7 @@ export default function Home() {
           <div>
             <SectionHeading
               title="RISE APP TECHNOLOGY"
-              subtitle="Effortless Membership Management at Your Fingertips"
+              subtitle="Effortless Registration Management at Your Fingertips"
             />
             <motion.p
               initial={{ opacity: 0, y: 20 }}
@@ -433,7 +433,7 @@ export default function Home() {
               transition={{ duration: 0.5, delay: 0.2 }}
               className="mb-8"
             >
-              The RISE app makes it simple to manage memberships, schedules, and
+              The RISE app makes it simple to manage registrations, schedules, and
               payments. Whether you're tracking your progress or managing
               multiple athletes, everything you need is right at your
               fingertips.
@@ -481,7 +481,7 @@ export default function Home() {
                     />
                   </svg>
                 </div>
-                <span>Easy Membership Control</span>
+                <span>Easy Registration Control</span>
               </div>
               <div className="flex items-center gap-2">
                 <div className="bg-[#ffb800]/10 rounded-full p-1">
@@ -526,7 +526,7 @@ export default function Home() {
             <div className="w-full h-full border-4 border-[#ffb800] rounded-lg overflow-hidden shadow-lg">
               <Image
                 src="/home-page-images/riseapp.svg"
-                alt="RISE Basketball Mobile App - Membership and Scheduling"
+                alt="RISE Basketball Mobile App - Registration and Scheduling"
                 width={500}
                 height={500}
                 className="w-full h-auto"

--- a/app/performance/page.tsx
+++ b/app/performance/page.tsx
@@ -285,7 +285,7 @@ export default function PerformancePage() {
       </ParallaxSection>
 
       {/* Memberships */}
-      <PerformanceMembershipsSection showHeading headingTitle="Memberships" containerClassName="bg-black" />
+      <PerformanceMembershipsSection showHeading headingTitle="Registrations" containerClassName="bg-black" />
 
       {/* Gallery */}
       <SectionContainer>

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -176,7 +176,7 @@ export default function ProfilePage() {
   // Profile tabs
   const profileTabs = [
     { id: "overview", label: "Overview" },
-    { id: "membership", label: "Membership" },
+    { id: "membership", label: "Registration" },
     { id: "schedule", label: "My Schedule" },
     { id: "waivers", label: "Waivers" },
   ];
@@ -486,7 +486,7 @@ export default function ProfilePage() {
                     <div className="w-10 h-10 rounded-lg bg-[#ffb800]/10 flex items-center justify-center">
                       <CreditCard className="h-5 w-5 text-[#ffb800]" />
                     </div>
-                    <h3 className="text-sm font-medium text-gray-400">Membership</h3>
+                    <h3 className="text-sm font-medium text-gray-400">Registration</h3>
                   </div>
                   {(userProfile?.membership_info || membership) ? (
                     <div>
@@ -501,7 +501,7 @@ export default function ProfilePage() {
                     </div>
                   ) : (
                     <div>
-                      <p className="text-gray-500 text-sm mb-3">No active membership</p>
+                      <p className="text-gray-500 text-sm mb-3">No active registration</p>
                       {/* Temporarily using Glofox link - old: onClick={() => router.push('/allmemberships') */}
                       <a
                         href="https://app.glofox.com/portal/#/branch/66464503a11addded10584e5/memberships"
@@ -698,7 +698,7 @@ export default function ProfilePage() {
           {activeTab === "membership" && (
             <>
             <div className="bg-gradient-to-br from-gray-900 to-gray-900/50 rounded-xl border border-gray-800 p-5">
-              <h3 className="text-lg font-semibold text-white mb-6">Membership Details</h3>
+              <h3 className="text-lg font-semibold text-white mb-6">Registration Details</h3>
 
               {membershipLoading ? (
                 <div className="animate-pulse space-y-4">
@@ -770,8 +770,8 @@ export default function ProfilePage() {
                   <div className="w-16 h-16 rounded-full bg-gray-800 flex items-center justify-center mx-auto mb-4">
                     <CreditCard className="h-8 w-8 text-gray-500" />
                   </div>
-                  <h4 className="text-lg font-semibold text-white mb-2">No Active Membership</h4>
-                  <p className="text-gray-400 mb-6">You don't have an active membership yet.</p>
+                  <h4 className="text-lg font-semibold text-white mb-2">No Active Registration</h4>
+                  <p className="text-gray-400 mb-6">You don't have an active registration yet.</p>
                   {/* Temporarily using Glofox link - old: onClick={() => router.push('/allmemberships') */}
                   <a
                     href="https://app.glofox.com/portal/#/branch/66464503a11addded10584e5/memberships"
@@ -779,7 +779,7 @@ export default function ProfilePage() {
                     rel="noopener noreferrer"
                     className="px-6 py-2.5 bg-[#ffb800] text-black font-semibold rounded-xl hover:bg-[#e0a300] transition-colors inline-block"
                   >
-                    Browse Memberships
+                    Browse Registrations
                   </a>
                 </div>
               )}
@@ -882,7 +882,7 @@ export default function ProfilePage() {
                         {subsidyUsage.slice(0, 5).map((usage) => {
                           const formatTransactionType = (type: string) => {
                             const typeMap: Record<string, string> = {
-                              'membership_payment': 'Membership Payment',
+                              'membership_payment': 'Registration Payment',
                               'event_payment': 'Event Payment',
                               'credit_purchase': 'Credit Purchase',
                               'refund': 'Refund',

--- a/app/refund/page.tsx
+++ b/app/refund/page.tsx
@@ -16,7 +16,7 @@ export default function RefundPolicyPage() {
             Participants have up to <strong>7 days before the program start date</strong> to withdraw and receive a full refund. Withdrawal requests must be submitted <strong>via email</strong> before the program begins.
           </p>
           <p className="mt-2 text-yellow-400 italic">
-            *Excludes Full-Year Memberships
+            *Excludes Full-Year Registrations
           </p>
           <p className="mt-2 text-red-400">
             Once the program has started, no refunds will be issued.
@@ -34,13 +34,13 @@ export default function RefundPolicyPage() {
 
         <section>
           <h2 className="text-xl font-semibold mb-2 text-white">
-            Full-Year Memberships
+            Full-Year Registrations
           </h2>
           <p>
-            All Full-Year Memberships are final. No cancellations or refunds will be issued after registration.
+            All Full-Year Registrations are final. No cancellations or refunds will be issued after registration.
           </p>
           <p className="mt-2">
-            The initial sign-up fee is <strong>non-refundable</strong>. For full membership details, please refer to the Member Contract available in your <Link href="/profile" className="text-yellow-400 underline">account</Link>.
+            The initial sign-up fee is <strong>non-refundable</strong>. For full registration details, please refer to the Member Contract available in your <Link href="/profile" className="text-yellow-400 underline">account</Link>.
           </p>
         </section>
 

--- a/components/basketballMembershipSection.tsx
+++ b/components/basketballMembershipSection.tsx
@@ -15,7 +15,7 @@ interface BasketballMembershipsSectionProps {
 
 export function BasketballMembershipsSection({
   showHeading = false,
-  headingTitle = "Basketball Memberships",
+  headingTitle = "Basketball Registrations",
   containerClassName
 }: BasketballMembershipsSectionProps) {
   const [displayPlans, setDisplayPlans] = useState<GridPlan[]>([]);

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -110,7 +110,7 @@ export default function Header() {
     "/basketball": [
       {
         href: "https://app.glofox.com/portal/#/branch/66464503a11addded10584e5/memberships",
-        label: "Memberships",
+        label: "Registrations",
       },
       { href: "/coaches", label: "Coaches" },
       { href: "/games", label: "Games" },
@@ -118,7 +118,7 @@ export default function Header() {
     "/performance": [
       {
         href: "https://app.glofox.com/portal/#/branch/66464503a11addded10584e5/memberships",
-        label: "Memberships",
+        label: "Registrations",
       },
     ],
     "/contact": [

--- a/components/membershipsSection.tsx
+++ b/components/membershipsSection.tsx
@@ -16,7 +16,7 @@ interface MembershipsSectionProps {
 
 export function MembershipsSection({
   showHeading = false,
-  headingTitle = "Memberships",
+  headingTitle = "Registrations",
   containerClassName,
   containerId
 }: MembershipsSectionProps = {}) {

--- a/components/performanceMembershipSection.tsx
+++ b/components/performanceMembershipSection.tsx
@@ -15,7 +15,7 @@ interface PerformanceMembershipsSectionProps {
 
 export function PerformanceMembershipsSection({
   showHeading = false,
-  headingTitle = "Memberships",
+  headingTitle = "Registrations",
   containerClassName
 }: PerformanceMembershipsSectionProps) {
   const [displayPlans, setDisplayPlans] = useState<GridPlan[]>([]);

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -99,7 +99,7 @@ export const MEMBERSHIP_PLANS = [
     id: "full-year",
     featured: true,
     badge: "BEST VALUE",
-    title: "RISE FULL YEAR Basketball Membership",
+    title: "RISE FULL YEAR Basketball Registration",
     price: 225,
     period: "month",
     description:
@@ -116,7 +116,7 @@ export const MEMBERSHIP_PLANS = [
     id: "jr-rise",
     featured: false,
     badge: "GREAT VALUE",
-    title: "Jr. RISE Basketball Membership",
+    title: "Jr. RISE Basketball Registration",
     price: 125,
     period: "month",
     description:
@@ -133,7 +133,7 @@ export const MEMBERSHIP_PLANS = [
     id: "performance",
     featured: false,
     badge: "GREAT VALUE",
-    title: "RISE Performance Membership",
+    title: "RISE Performance Registration",
     price: 145,
     period: "month",
     description:


### PR DESCRIPTION
## Summary
- Replaced all user-facing instances of "Membership" with "Registration" per client request
- Updated nav labels, page headings, meta descriptions, profile page, refund policy, plan titles, and section component defaults
- Internal code (variable names, imports, API endpoints, external URLs) left unchanged

## Test plan
- [ ] Verify nav dropdown labels show "Registrations" under Basketball and Performance
- [ ] Verify homepage headings and app technology section use "Registration"
- [ ] Verify profile page tab, card, and empty states say "Registration"
- [ ] Verify refund policy page says "Full-Year Registrations"
- [ ] Verify basketball and performance page section headings updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)